### PR TITLE
Fix account management model rates links

### DIFF
--- a/docs/agent-studio/components/advanced/llm-assisstant.mdx
+++ b/docs/agent-studio/components/advanced/llm-assisstant.mdx
@@ -2,7 +2,7 @@
 
 The `LLM Assistant` is designed to handle chat conversations, tracking and remembering the conversation flow. It's perfect for agents who need consistent and coherent interactions with users.
 
-> 📝 **Note:** We provide the model for you without any configuration required [Account Management - Model Rates](account_management/modelRates), and the flexibility to bring your own model.
+> 📝 **Note:** We provide the model for you without any configuration required [Account Management - Model Rates](../../../account-management/model-rates), and the flexibility to bring your own model.
 
 <Arcade  src="https://demo.arcade.software/feB8bIw53rxIILXr2QwP?embed&embed_mobile=tab&embed_desktop=inline&show_copy_link=true" title="LLM Assistant | SmythOS" />
 

--- a/docs/agent-studio/components/base/classifier.mdx
+++ b/docs/agent-studio/components/base/classifier.mdx
@@ -2,7 +2,7 @@
 
 The `Classifier` component categorizes input data into predefined groups for efficient data management.
 
-> 📝 **Note:** We provide the model for you without any configuration required [Account Management - Model Rates](account_management/modelRates), and the flexibility to bring your own model.
+> 📝 **Note:** We provide the model for you without any configuration required [Account Management - Model Rates](../../../account-management/model-rates), and the flexibility to bring your own model.
 
 <Arcade  src="https://demo.arcade.software/QvVcl616TZ2ubN30z5Nh?embed&embed_mobile=tab&embed_desktop=inline&show_copy_link=true"
  title="Classifier | SmythOS"/>

--- a/docs/agent-studio/components/base/gen-ai-llm.mdx
+++ b/docs/agent-studio/components/base/gen-ai-llm.mdx
@@ -2,7 +2,7 @@
 
 Generate AI responses using various input file types.
 
-> 📝 **Note:** We provide the model for you without any configuration required [Account Management - Model Rates](account_management/modelRates), and the flexibility to bring your own model.
+> 📝 **Note:** We provide the model for you without any configuration required [Account Management - Model Rates](../../../account-management/model-rates), and the flexibility to bring your own model.
 
 ---
 

--- a/docs/agent-studio/components/base/image-generator.mdx
+++ b/docs/agent-studio/components/base/image-generator.mdx
@@ -2,7 +2,7 @@
 
 The **Image Generator** component uses advanced models to generate images, enhancing the agent's capabilities for sophisticated image manipulation.
 
-> 📝 **Note:** We provide the model for you without any configuration required [Account Management - Model Rates](account_management/modelRates).
+> 📝 **Note:** We provide the model for you without any configuration required [Account Management - Model Rates](../../../account-management/model-rates).
 
 <Arcade  src="https://demo.arcade.software/AroFQEL8xuIPIjCGhH7H?embed&embed_mobile=tab&embed_desktop=inline&show_copy_link=true" title="Image Generator | SmythOS"/>
 

--- a/docs/agent-studio/components/tools/node-js.mdx
+++ b/docs/agent-studio/components/tools/node-js.mdx
@@ -1,6 +1,6 @@
 # 🚀 NodeJS (Serverless) Component
 
-With the NodeJS component, you can run advanced libraries and code directly in your agent workflow. Code is executed in a sandboxed AWS Lambda environment. We provide the environment for you without any configuration required [Account Management - Model Rates](account_management/modelRates), and the flexibility to bring your own server in Advanced settings.
+With the NodeJS component, you can run advanced libraries and code directly in your agent workflow. Code is executed in a sandboxed AWS Lambda environment. We provide the environment for you without any configuration required [Account Management - Model Rates](../../../account-management/model-rates), and the flexibility to bring your own server in Advanced settings.
 
 <Arcade src="https://demo.arcade.software/nGmhHgytddwjdFCedz9R?embed&embed_mobile=tab&embed_desktop=inline&show_copy_link=true" title="SmythOS | Serverless Code"/>
 

--- a/docs/agent-studio/components/tools/web-scrape.mdx
+++ b/docs/agent-studio/components/tools/web-scrape.mdx
@@ -2,7 +2,7 @@
 
 The Web Scrape Component enables you to extract content from webpages, whether you're targeting a single page or multiple pages.
 
-> 📝 **Note:** We provide the model for you without any configuration required [Account Management - Model Rates](account_management/modelRates).
+> 📝 **Note:** We provide the model for you without any configuration required [Account Management - Model Rates](../../../account-management/model-rates).
 
 <Arcade src="https://demo.arcade.software/CGogKgUeHYFSff4xVZ1Z?embed&embed_mobile=tab&embed_desktop=inline&show_copy_link=true" title="WebScrape | SmythOS" />
 

--- a/docs/agent-studio/components/tools/web-search.mdx
+++ b/docs/agent-studio/components/tools/web-search.mdx
@@ -2,7 +2,7 @@
 
 This component can perform web searches and present the results based on a given query.
 
-> 📝 **Note:** We provide the model for you without any configuration required [Account Management - Model Rates](account_management/modelRates).
+> 📝 **Note:** We provide the model for you without any configuration required [Account Management - Model Rates](../../../account-management/model-rates).
 
 <Arcade  src="https://demo.arcade.software/yGvNUREteuUqZ7ryFPAW?embed&embed_mobile=tab&embed_desktop=inline&show_copy_link=true" title="WebSearch | SmythOS" />
 

--- a/docs/agent-studio/integrations/list-of-studio-integrations/openapi-integration.mdx
+++ b/docs/agent-studio/integrations/list-of-studio-integrations/openapi-integration.mdx
@@ -1,6 +1,6 @@
 # 🌐 OpenAPI
 
-> 📝 **Note:** We provide the model for you without any configuration required [Account Management - Model Rates](account_management/modelRates), and the flexibility to bring your own model.
+> 📝 **Note:** We provide the model for you without any configuration required [Account Management - Model Rates](../../../account-management/model-rates), and the flexibility to bring your own model.
 
 <Arcade src="https://demo.arcade.software/ePHO36pfzhkHqMLU0Khy?embed&embed_mobile=tab&embed_desktop=inline&show_copy_link=true" title="OpenAPI | SmythOS" />
 ---


### PR DESCRIPTION
## Summary
- update doc links from `account_management/modelRates` to `account-management/model-rates`
- fix relative paths