### PR TITLE
Update comment in ValueCard

### DIFF
--- a/src/components/ValueCard.tsx
+++ b/src/components/ValueCard.tsx
@@ -9,7 +9,7 @@ export interface ValueCardProps {
 const ValueCard: React.FC<ValueCardProps> = ({
   title,
   description,
-  highlightColor = '#3efcc2', // YHellow -> #ffff00
+  highlightColor = '#3efcc2', // Yellow -> #ffff00
 }) => {
   return (
     <div


### PR DESCRIPTION
- fix typo in `ValueCard` component's default highlight color comment
