### PR TITLE
Fixed Broken SDK Repo Link for Examples 

### DIFF
--- a/docs/agent-runtime/sdk-guide.mdx
+++ b/docs/agent-runtime/sdk-guide.mdx
@@ -66,7 +66,7 @@ const result = await agent.prompt('Tell me about SmythOS.');
 console.log(result);
 ```
 
-See more complete examples in the [SDK repo](https://github.com/SmythOS/sre/tree/main/packages/examples).
+See more complete examples in the [SRE Examples repo](https://github.com/SmythOS/sre/tree/main/examples).
 
 <Spacer size="md" />
 


### PR DESCRIPTION
The SDK Repo Link found on the https://smythos.com/docs/agent-runtime/sdk-guide/.  I updated it to point to https://github.com/SmythOS/sre/tree/main/examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “See more complete examples” link in the SDK guide to point to the correct examples repository, improving navigation for readers.
  * No content changes to the surrounding example; only the hyperlink destination was corrected.
  * No impact on functionality or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->